### PR TITLE
添加组成员接口限制owner或管理员才能操作

### DIFF
--- a/server/controllers/group.js
+++ b/server/controllers/group.js
@@ -246,6 +246,10 @@ class groupController extends baseController {
   async addMember(ctx) {
     let params = ctx.params;
     let groupInst = yapi.getInst(groupModel);
+    
+    if ((await this.checkAuth(params.id, 'group', 'danger')) !== true) {
+      return (ctx.body = yapi.commons.resReturn(null, 405, '没有权限'));
+    }
 
     params.role = ['owner', 'dev', 'guest'].find(v => v === params.role) || 'dev';
     let add_members = [];


### PR DESCRIPTION
该接口可被普通成员模拟调用并把自己添加为owner，增加该限制